### PR TITLE
Minor bug fix

### DIFF
--- a/app/Commands/Export/ExportCommand.php
+++ b/app/Commands/Export/ExportCommand.php
@@ -74,7 +74,7 @@ class ExportCommand extends Command
             });
 
             $this->tasks('Running pre upload validation', function () use ($validate): bool {
-                if (! $validate->validate(getcwd(), ["size,$this->file_name"])) {
+                if (! $validate->validate(getcwd(), ["size:$this->file_name"])) {
                     $this->validationError($validate->errors());
 
                     return false;


### PR DESCRIPTION
### What are you trying to accomplish with this PR?
When validating attributes with arguments, a comma was formerly used to separate arguments, I had changed it to a colon in the validation class. This PR makes the same change in the zip command class. 
### Why did you want to accomplish this?

### How did you accomplish this?

### What could go wrong?

### ToDos
- [x] It is safe to rollback these changes should an error occur in production.
- [x] I have tested these changes.
- [x] There are automated tests for these changes.
