### PR TITLE
Allow workflow to run when pushing to master

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,7 +5,9 @@ on:
     branches:
       - master
       - dev
-
+  push:
+    branches:
+      - master
 jobs:
   app-tests:
     runs-on: ubuntu-latest
@@ -17,4 +19,3 @@ jobs:
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist --ignore-platform-reqs
       - name: Execute tests (Unit and Feature tests) via PHPUnit
         run: ./vendor/bin/phpunit
-


### PR DESCRIPTION
### What are you trying to accomplish with this PR?
Allow workflow to run when pushing to master
### Why did you want to accomplish this?
To ensure that workflows esspecially test suites are run always when merging to master
### How did you accomplish this?
Add a push option to the main.yml file
### What could go wrong?
none
### ToDos
- [x] It is safe to rollback these changes should an error occur in production.
- [ ] I have tested these changes.
- [ ] There are automated tests for these changes.
