### PR TITLE
Fix return value exception

### DIFF
--- a/app/Services/BrowserService.php
+++ b/app/Services/BrowserService.php
@@ -18,7 +18,8 @@ class BrowserService
             case 'WINNT':
                 return 'start';
                 break;
-            default:  'xdg-open';
+            default:
+                return 'xdg-open';
         };
     }
 


### PR DESCRIPTION
Default case still must return something in order to respect 'string' return type. Otherwise `Return value of App\Services\BrowserService::getSystemCommand() must be of the type string, none returned` is thrown

### What are you trying to accomplish with this PR?
Fix exception on linux system

### Why did you want to accomplish this?
Because it doesn't work on linux (WSL)

### How did you accomplish this?
By fixing switch/case statement to proper form.

### What could go wrong?
Nothing as it's already broken

### ToDos
- [ ] It is safe to rollback these changes should an error occur in production.
- [ ] I have tested these changes.
- [ ] There are automated tests for these changes.
