### PR TITLE
fix: Ensure the explode function only uses the first instance of the …

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Remove exisiting builds
         run: rm -r ./builds/*
       - name: Build a new executable
-        run: php psb app:build --build-version=0.2.0
+        run: php psb app:build --build-version=0.2.1
       - name: Commit executable to the repo
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/app/Services/ValidationService.php
+++ b/app/Services/ValidationService.php
@@ -35,7 +35,7 @@ class ValidationService
 
     protected function parseRule(string $rule): array
     {
-        $pieces = explode(':', $rule);
+        $pieces = explode(':', $rule, 2);
 
         return strpos($rule, ':') === false
                 ? ['validate' . Str::studly($rule), null]

--- a/tests/Unit/Services/ValidationTest.php
+++ b/tests/Unit/Services/ValidationTest.php
@@ -60,6 +60,8 @@ class ValidationTest extends TestCase
         config(['psb.max_file_size' => -1]);
 
         Storage::makeDirectory('project');
+        Storage::makeDirectory('project:withcolon');
+
         Storage::put('project/index.zip', "<?php echo 'hello' ?>");
 
         $this->assertFalse($this->validator->validate(Storage::path('project'), [
@@ -74,6 +76,13 @@ class ValidationTest extends TestCase
 
         $this->assertTrue($this->validator->validate(Storage::path('project'), [
             'size:' . Storage::path('project/hello.zip'),
+        ]));
+
+        /** test for file path containing colon */
+        Storage::put('project:withcolon/hello.zip', "<?php echo 'hello' ?>");
+
+        $this->assertTrue($this->validator->validate(Storage::path('project'), [
+            'size:' . Storage::path('project:withcolon/hello.zip'),
         ]));
     }
 


### PR DESCRIPTION
…delimeter

### What are you trying to accomplish with this PR?
Currently, projects cannot be exported from windows computer . It throws an error which is caused by PHPSandbox CLI attempting to read the size of the wrong file. This PR fixes that. The issue occurs only on windows operation system. 
### Why did you want to accomplish this?
To allow windows users to export local projects to PHPSandbox.
### How did you accomplish this?
By making the explode function in the validation parser method in the validation class always return a array of two elements . This way only the first colon would be considered a delimiter. The second can then be treated as part of the file path
### What could go wrong?
none
### ToDos
- [x] It is safe to rollback these changes should an error occur in production.
- [x] I have tested these changes.
- [x] There are automated tests for these changes.
